### PR TITLE
Simplify divisibility check

### DIFF
--- a/tools/birthNumber/generateBirthNumber.ts
+++ b/tools/birthNumber/generateBirthNumber.ts
@@ -9,15 +9,9 @@ function randomIntFromInterval(min, max) { // min and max included
 }
 
 function testRc(strRc: string): boolean {
-	const result =
-		parseInt(strRc[0]) +
-		parseInt(strRc[2]) +
-		parseInt(strRc[4]) +
-		parseInt(strRc[6]) +
-		parseInt(strRc[8]) -
-		(parseInt(strRc[1]) + parseInt(strRc[3]) + parseInt(strRc[5]) + parseInt(strRc[7]) + parseInt(strRc[9]));
-	return result === 0 || result % 11 === 0;
+	return parseInt(strRc) % 11 == 0;
 }
+
 export interface BirthNumbersData {
 	birthNumbers: string[];
 	settings: any;


### PR DESCRIPTION
The divisibility check from wikipedia works, but is just for "humans". For computers, it's easier to just parse all birth number and check divisibility.

There is a special case for numbers before 1985, but not important enough to implement here.

(I am adding PRs here, because this could end up being someone's reference implementation, as it has good google/github search rank... the speed difference is otherwise negligible)